### PR TITLE
Update constants.py to include Sxclint/Sxclic/Sxaia

### DIFF
--- a/riscv_config/constants.py
+++ b/riscv_config/constants.py
@@ -32,7 +32,7 @@ Z_extensions = [
         "Zpn", "Zpsf"
 ] + Zve_extensions + Zvl_extensions
 
-S_extensions = ['Smrnmi','Svnapot']
+S_extensions = ['Smrnmi','Svnapot','Smclint','Ssclint','Smclic','Ssclic','Smaia','Ssaia']
 
 sub_extensions = Z_extensions + S_extensions
 


### PR DESCRIPTION
Added clint/clic/aia options as valid S_extensions
Needed for https://github.com/riscv-non-isa/riscv-arch-test/pull/372